### PR TITLE
Refactor FAIRLinked for PyPI-ready structure and reverse mapping support (v0.3.0.0)

### DIFF
--- a/FAIRLinked/add_ontology_term.py
+++ b/FAIRLinked/add_ontology_term.py
@@ -2,15 +2,11 @@
 """
 Script to interactively add a new term to an existing ontology in Turtle (TTL) format.
 
-It prompts the user for required metadata such as label, parent class, value type, and unit,
-and appends the formatted RDF triples to a new file (original name suffixed with _rxl895).
-
-This script is useful for ontology developers working on modular additions while preserving
-the integrity of the original ontology file.
+Prompts the user for term metadata (label, parent class, value type, unit) and appends RDF triples
+to a new file (original name suffixed with _rxl895) to preserve the original.
 """
 
 import os
-import sys
 from datetime import datetime
 
 def get_term_details():
@@ -18,10 +14,7 @@ def get_term_details():
     Prompt the user to input details for a new ontology term.
 
     Returns:
-        dict: A dictionary containing term_name, label, parent_class, definition,
-              value_type, and unit.
-    Raises:
-        ValueError: If required inputs are left empty or invalid selections are made.
+        dict: A dictionary with term_name, label, parent_class, definition, value_type, and unit.
     """
     print("\nPlease provide the following details for the new term:")
     
@@ -47,17 +40,14 @@ def get_term_details():
             parent_class = parent_classes[int(parent_choice) - 1]
             break
         except (ValueError, IndexError):
-            print("Invalid selection. Please enter a number between 1 and", len(parent_classes))
+            print("Invalid selection. Please enter a valid number.")
     
     definition = input("Enter the definition: ").strip()
     if not definition:
         raise ValueError("Definition cannot be empty")
     
     print("\nSelect value type (if applicable):")
-    value_types = [
-        "xsd:string", "xsd:float", "xsd:integer", "xsd:dateTime",
-        "rdf:Seq", "None"
-    ]
+    value_types = ["xsd:string", "xsd:float", "xsd:integer", "xsd:dateTime", "rdf:Seq", "None"]
     for i, vtype in enumerate(value_types, 1):
         print(f"{i}. {vtype}")
     
@@ -67,7 +57,7 @@ def get_term_details():
             value_type = value_types[int(value_choice) - 1]
             break
         except (ValueError, IndexError):
-            print("Invalid selection. Please enter a number between 1 and", len(value_types))
+            print("Invalid selection. Please enter a valid number.")
     
     unit = None
     if value_type in ["xsd:float", "xsd:integer"]:
@@ -89,7 +79,7 @@ def get_term_details():
                 unit = units[int(unit_choice) - 1]
                 break
             except (ValueError, IndexError):
-                print("Invalid selection. Please enter a number between 1 and", len(units))
+                print("Invalid selection. Please enter a valid number.")
     
     return {
         "term_name": term_name,
@@ -102,13 +92,13 @@ def get_term_details():
 
 def format_term(term_details):
     """
-    Format term details into RDF/Turtle syntax for ontology inclusion.
+    Format term details into RDF/Turtle syntax.
 
     Args:
-        term_details (dict): Dictionary with metadata for the new term.
+        term_details (dict): Metadata for the new term.
 
     Returns:
-        str: A string representing RDF Turtle triples to be appended.
+        str: RDF Turtle triples to be appended.
     """
     term = f"\n# Added on {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n"
     term += f"mds:{term_details['term_name']} a owl:Class ;\n"
@@ -117,23 +107,23 @@ def format_term(term_details):
     term += f"    skos:definition \"{term_details['definition']}\""
     
     if term_details['value_type'] != "None":
-        term += " ;\n    mds:value " + term_details['value_type']
+        term += f" ;\n    mds:value {term_details['value_type']}"
     
     if term_details['unit'] and term_details['unit'] != "None":
-        term += " ;\n    mds:unit " + term_details['unit']
+        term += f" ;\n    mds:unit {term_details['unit']}"
     
     term += " .\n"
     return term
 
 def add_term_to_ontology(ontology_path):
     """
-    Add a new term to a TTL ontology file and write the result to a new file.
+    Add a new term to a TTL ontology file and write to a new versioned file.
 
     Args:
-        ontology_path (str): Path to the existing ontology TTL file.
+        ontology_path (str): Path to the TTL ontology file.
 
     Returns:
-        bool: True if term was added successfully, False otherwise.
+        bool: True if added successfully, else False.
     """
     try:
         term_details = get_term_details()
@@ -142,8 +132,7 @@ def add_term_to_ontology(ontology_path):
         directory = os.path.dirname(ontology_path)
         filename = os.path.basename(ontology_path)
         name, ext = os.path.splitext(filename)
-        new_filename = f"{name}_rxl895{ext}"
-        new_path = os.path.join(directory, new_filename)
+        new_path = os.path.join(directory, f"{name}_rxl895{ext}")
         
         with open(ontology_path, 'r', encoding='utf-8') as f:
             content = f.read()
@@ -152,25 +141,9 @@ def add_term_to_ontology(ontology_path):
             f.write(content)
             f.write(new_term)
         
-        print(f"\n✅ Successfully added new term 'mds:{term_details['term_name']}' to {new_path}")
-        print(f"📁 Original file '{ontology_path}' was not modified.")
+        print(f"\n✅ Term 'mds:{term_details['term_name']}' added to: {new_path}")
         return True
 
     except Exception as e:
         print(f"\n❌ Error: {str(e)}")
         return False
-
-def main():
-    """
-    Main function to prompt the user for an ontology file and add a new term.
-    """
-    ontology_path = input("Enter the path to your ontology file: ").strip()
-    
-    if not os.path.exists(ontology_path):
-        print(f"❌ Error: File '{ontology_path}' does not exist.")
-        return
-    
-    add_term_to_ontology(ontology_path)
-
-if __name__ == "__main__":
-    main()

--- a/FAIRLinked/download_mds_ontology.py
+++ b/FAIRLinked/download_mds_ontology.py
@@ -1,16 +1,17 @@
+#!/usr/bin/env python3
 """
-download_mds_onto_rxl895.py
+download_mds_ontology.py
 
-Automates the download of ontology files from the SDLE public website using Selenium.
+Automates the download of MDS-Onto files from the SDLE public website using Selenium.
 
 Functionality:
 - Clicks the main `.ttl` download button
 - Opens the dropdown to download `.jsonld`, `.nt`, and `.owl` formats
-- Waits for each download to complete and renames the files with a timestamp
-- Saves screenshots for debugging if any file is not found
+- Waits for each download to complete and renames the files
+- Optionally captures screenshots for debugging if files are missing
 
-Author: Ritika (rxl895)
-Date: July 2025
+Functions:
+- download_mds_ontology(download_dir): Runs the entire download sequence
 """
 
 import os
@@ -22,35 +23,15 @@ from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
-# === CONFIGURATION ===
-download_dir = "/Users/lambaritu67/Desktop/fairlinked/downloads"
-os.makedirs(download_dir, exist_ok=True)
-
-# Set up Chrome with download preferences
-options = Options()
-# options.add_argument("--headless")  # Uncomment for headless mode
-options.add_experimental_option("prefs", {
-    "download.default_directory": download_dir,
-    "download.prompt_for_download": False,
-    "download.directory_upgrade": True,
-    "safebrowsing.enabled": True
-})
-
-driver = webdriver.Chrome(options=options)
-
-def wait_for_download_and_rename(extension, label):
+def wait_for_download_and_rename(download_dir, extension, label):
     """
     Waits for a new file with the given extension to appear in the download directory.
     Once detected, renames it with a timestamp and a user-friendly label.
 
     Args:
+        download_dir (str): Directory where downloads are saved.
         extension (str): File extension to look for (e.g., '.ttl', '.jsonld').
         label (str): Short label to prefix the renamed file (e.g., 'ttl', 'jsonld').
-
-    Behavior:
-        - Waits up to 30 seconds for the file to appear.
-        - Renames the first matching file found as: MDS_Onto-<label>-<timestamp><extension>
-        - Prints a success or timeout message.
     """
     print(f"⏳ Waiting for {extension} file...")
     before = set(os.listdir(download_dir))
@@ -71,62 +52,76 @@ def wait_for_download_and_rename(extension, label):
             return
     print(f"❌ Timeout: {extension} file not found.")
 
-try:
-    # === STEP 0: Load the SDLE website ===
-    driver.get("https://cwrusdle.bitbucket.io/")
+def download_mds_ontology(download_dir):
+    """
+    Automates downloading of MDS-Onto `.ttl`, `.jsonld`, `.nt`, and `.owl` files.
 
-    # === STEP 1: Click the main "Download .ttl file" button ===
-    ttl_button = WebDriverWait(driver, 10).until(
-        EC.element_to_be_clickable((By.XPATH, "//button[contains(., 'Download .ttl file')]"))
-    )
-    ttl_button.click()
-    wait_for_download_and_rename(".ttl", "ttl")
+    Args:
+        download_dir (str): Directory to save the downloaded files.
+    """
+    os.makedirs(download_dir, exist_ok=True)
 
-    # === STEP 2: Open the dropdown next to the "Download .ttl file" button ===
-    dropdown_arrow_xpath = "//h1[contains(text(), 'FindTheDocs')]/following::button[@aria-label='dropdown menu'][1]"
-    dropdown_arrow = WebDriverWait(driver, 10).until(
-        EC.element_to_be_clickable((By.XPATH, dropdown_arrow_xpath))
-    )
-    dropdown_arrow.click()
-    print("📂 Opened download dropdown")
+    options = Options()
+    # options.add_argument("--headless")  # Uncomment for headless operation
+    options.add_experimental_option("prefs", {
+        "download.default_directory": download_dir,
+        "download.prompt_for_download": False,
+        "download.directory_upgrade": True,
+        "safebrowsing.enabled": True
+    })
 
-    # === STEP 3: Download additional formats from dropdown ===
-    file_options = {
-        "jsonld": ("Download JSON-LD file", ".jsonld"),
-        "nt": ("Download .nt file", ".nt"),
-        "rdfowl": ("Download RDF/OWL file", ".owl")
-    }
+    driver = webdriver.Chrome(options=options)
+    dropdown_xpath = "//h1[contains(text(), 'FindTheDocs')]/following::button[@aria-label='dropdown menu'][1]"
 
-    for label, (visible_text, extension) in file_options.items():
-        driver.save_screenshot(f"debug_{label}.png")
+    try:
+        driver.get("https://cwrusdle.bitbucket.io/")
 
-        # Wait for menu items to appear
-        elements = WebDriverWait(driver, 20).until(
-            EC.presence_of_all_elements_located((By.XPATH, "//li[@role='menuitem']"))
+        # Download .ttl
+        ttl_button = WebDriverWait(driver, 10).until(
+            EC.element_to_be_clickable((By.XPATH, "//button[contains(., 'Download .ttl file')]"))
         )
-        print("📋 Found menu items:", [e.text.strip() for e in elements])
+        ttl_button.click()
+        wait_for_download_and_rename(download_dir, ".ttl", "ttl")
 
-        # Find the correct menu item and click it
-        clicked = False
-        for el in elements:
-            if el.text.strip() == visible_text:
-                el.click()
-                clicked = True
-                break
-
-        if not clicked:
-            print(f"❌ Could not find menu item: '{visible_text}'")
-            driver.save_screenshot(f"not_found_{label}.png")
-            continue
-
-        wait_for_download_and_rename(extension, label)
-
-        # Re-open dropdown for next file
-        time.sleep(0.5)
+        # Open dropdown
         dropdown_arrow = WebDriverWait(driver, 10).until(
-            EC.element_to_be_clickable((By.XPATH, dropdown_arrow_xpath))
+            EC.element_to_be_clickable((By.XPATH, dropdown_xpath))
         )
         dropdown_arrow.click()
+        print("📂 Opened download dropdown")
 
-finally:
-    driver.quit()
+        file_options = {
+            "jsonld": ("Download JSON-LD file", ".jsonld"),
+            "nt": ("Download .nt file", ".nt"),
+            "rdfowl": ("Download RDF/OWL file", ".owl")
+        }
+
+        for label, (visible_text, extension) in file_options.items():
+            # Wait for menu items
+            elements = WebDriverWait(driver, 20).until(
+                EC.presence_of_all_elements_located((By.XPATH, "//li[@role='menuitem']"))
+            )
+            print("📋 Found menu items:", [e.text.strip() for e in elements])
+
+            clicked = False
+            for el in elements:
+                if el.text.strip() == visible_text:
+                    el.click()
+                    clicked = True
+                    break
+
+            if not clicked:
+                print(f"❌ Could not find menu item: '{visible_text}'")
+                continue
+
+            wait_for_download_and_rename(download_dir, extension, label)
+
+            # Reopen dropdown for next file
+            time.sleep(0.5)
+            dropdown_arrow = WebDriverWait(driver, 10).until(
+                EC.element_to_be_clickable((By.XPATH, dropdown_xpath))
+            )
+            dropdown_arrow.click()
+
+    finally:
+        driver.quit()

--- a/FAIRLinked/rdf_to_table_converter.py
+++ b/FAIRLinked/rdf_to_table_converter.py
@@ -1,230 +1,139 @@
 import os
 import json
-import re
-from rdflib import Graph, URIRef, Literal, Namespace
-from rdflib.namespace import RDF, SKOS, DCTERMS, XSD
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
-
-from packages.FAIRLinkedPy.FAIRLinked.utility import NAMESPACE_MAP
+from rdflib import Graph
+from .utility import NAMESPACE_MAP  # Ensure this exists in your package
 
 
 def _guess_rdf_format(filename):
-    """
-    Guess the RDF serialization format based on file extension.
-
-    Args:
-        filename (str): Path to the RDF file.
-
-    Returns:
-        str: RDF format string (e.g., 'turtle', 'json-ld').
-
-    Raises:
-        ValueError: If file extension is unrecognized.
-    """
     if filename.lower().endswith('.ttl'):
         return "turtle"
     elif filename.lower().endswith(('.jsonld', '.json-ld')):
         return "json-ld"
     else:
-        raise ValueError(f"Unknown RDF file extension for: {filename}")
+        raise ValueError(f"Unknown RDF file extension: {filename}")
 
 
-def _parse_single_rdf_graph(g):
-    """
-    Convert an RDF graph to a pivoted DataFrame (wide format).
-
-    Args:
-        g (rdflib.Graph): RDF graph to parse.
-
-    Returns:
-        tuple:
-            - pd.DataFrame: Pivoted DataFrame with subject as index.
-            - dict: Placeholder for variable metadata (currently empty).
-    """
-    rows = []
-    for s, p, o in g:
-        rows.append({"subject": str(s), "predicate": str(p), "object": str(o)})
-
+def _parse_single_rdf_graph(graph):
+    rows = [{"subject": str(s), "predicate": str(p), "object": str(o)} for s, p, o in graph]
     df = pd.DataFrame(rows)
     if not df.empty:
-        df_pivot = df.pivot_table(
-            index='subject',
-            columns='predicate',
-            values='object',
-            aggfunc=lambda x: x.tolist()
-        )
+        df_pivot = df.pivot_table(index='subject', columns='predicate', values='object', aggfunc=lambda x: x.tolist())
         df_pivot.reset_index(inplace=True)
     else:
         df_pivot = df
+    return df_pivot, {}  # Metadata extraction placeholder
 
-    return df_pivot, {}
 
-
-def parse_rdf_to_df(file_path: str,
-                    variable_metadata_json_path: str,
-                    arrow_output_path: str) -> tuple:
+def parse_rdf_to_df(file_path, variable_metadata_json_path, arrow_output_path):
     """
-    Parse one or more RDF files into a combined DataFrame, generate variable metadata,
-    and export the results in Parquet, JSON, CSV, and Excel formats.
+    Convert RDF (.ttl/.jsonld) files to a unified DataFrame and save in multiple formats.
 
     Args:
-        file_path (str): RDF file or directory path.
-        variable_metadata_json_path (str): Output path for variable metadata JSON.
-        arrow_output_path (str): Output path for the Parquet table.
+        file_path (str): RDF file or directory.
+        variable_metadata_json_path (str): Where to save metadata JSON (and CSV).
+        arrow_output_path (str): Where to save Arrow/Parquet/CSV/Excel/JSON outputs.
 
     Returns:
-        tuple:
-            - pa.Table: Final Arrow table.
-            - dict: Final variable metadata.
+        tuple: (Arrow Table, Variable Metadata Dictionary)
     """
     rdf_files = _collect_rdf_files(file_path)
     if not rdf_files:
-        raise ValueError(f"No RDF files (.ttl, .jsonld, .json-ld) found in '{file_path}'")
+        raise ValueError(f"No RDF files found in: {file_path}")
 
     all_dfs = []
-    final_variable_metadata = {}
+    metadata = {}
 
     for f in rdf_files:
         rdf_format = _guess_rdf_format(f)
-        print(f"\nParsing file: {f} as {rdf_format} ...")
-
+        print(f"\n🔍 Parsing: {f} ({rdf_format})")
         g = Graph()
-        g.parse(source=f, format=rdf_format)
+        g.parse(f, format=rdf_format)
 
-        partial_df, partial_metadata = _parse_single_rdf_graph(g)
+        df, meta = _parse_single_rdf_graph(g)
+        if not df.empty:
+            all_dfs.append(df)
 
-        if partial_df is not None and not partial_df.empty:
-            all_dfs.append(partial_df)
-
-        for var_name, pm in partial_metadata.items():
-            if var_name not in final_variable_metadata:
-                final_variable_metadata[var_name] = pm
+        for var, md in meta.items():
+            if var not in metadata:
+                metadata[var] = md
             else:
-                existing_units = set(final_variable_metadata[var_name].get("Unit", []))
-                new_units = set(pm.get("Unit", []))
-                final_variable_metadata[var_name]["Unit"] = sorted(existing_units.union(new_units))
-
-                if (not final_variable_metadata[var_name].get("AltLabel")
-                        and pm.get("AltLabel")):
-                    final_variable_metadata[var_name]["AltLabel"] = pm["AltLabel"]
-                if (not final_variable_metadata[var_name].get("Category")
-                        and pm.get("Category")):
-                    final_variable_metadata[var_name]["Category"] = pm["Category"]
-                if (final_variable_metadata[var_name].get("IsMeasure", "No") == "No"
-                        and pm.get("IsMeasure", "No") == "Yes"):
-                    final_variable_metadata[var_name]["IsMeasure"] = "Yes"
+                metadata[var]["Unit"] = sorted(set(metadata[var].get("Unit", [])).union(md.get("Unit", [])))
+                for key in ["AltLabel", "Category", "IsMeasure"]:
+                    if not metadata[var].get(key) and md.get(key):
+                        metadata[var][key] = md[key]
 
     final_df = pd.concat(all_dfs, ignore_index=True) if all_dfs else pd.DataFrame()
 
     if "ExperimentId" in final_df.columns:
-        final_df.sort_values(by="ExperimentId", inplace=True)
+        final_df.sort_values("ExperimentId", inplace=True)
 
-    var_categories = {
-        vn: (final_variable_metadata[vn].get("Category") or "")
-        for vn in final_variable_metadata
-    }
-    all_cols = list(final_df.columns)
-    if "ExperimentId" in all_cols:
-        all_cols.remove("ExperimentId")
-    all_cols.sort(key=lambda c: (var_categories.get(c, ""), c))
-    final_cols = ["ExperimentId"] + all_cols if "ExperimentId" in final_df.columns else all_cols
-    final_df = final_df[final_cols]
+    var_categories = {k: metadata[k].get("Category", "") for k in metadata}
+    reordered = _reorder_columns(final_df, var_categories)
 
-    final_table = pa.Table.from_pandas(final_df, preserve_index=False)
+    final_table = pa.Table.from_pandas(reordered, preserve_index=False)
 
-    with open(variable_metadata_json_path, "w", encoding="utf-8") as outf:
-        json.dump(final_variable_metadata, outf, indent=2, ensure_ascii=False)
+    _save_all_outputs(reordered, final_table, variable_metadata_json_path, arrow_output_path)
+    _print_final_stats_and_preview(reordered, var_categories, rdf_files, file_path)
 
-    if variable_metadata_json_path.lower().endswith(".json"):
-        variable_metadata_csv_path = variable_metadata_json_path.replace(".json", ".csv")
-        metadata_df = pd.DataFrame.from_dict(final_variable_metadata, orient="index")
-        metadata_df.insert(0, "Variable", metadata_df.index)
-        metadata_df.reset_index(drop=True, inplace=True)
-        metadata_df.to_csv(variable_metadata_csv_path, index=False)
-        print(f"✅ Saved metadata CSV to: {variable_metadata_csv_path}")
-
-    pq.write_table(final_table, arrow_output_path)
-
-    final_json_path = arrow_output_path.replace(".parquet", ".json")
-    final_df.to_json(final_json_path, orient="records", indent=2)
-    print(f"✅ Saved final DataFrame as JSON to: {final_json_path}")
-
-    final_csv_path = arrow_output_path.replace(".parquet", ".csv")
-    final_df.to_csv(final_csv_path, index=False)
-    print(f"✅ Saved final DataFrame as CSV to: {final_csv_path}")
-
-    final_excel_path = arrow_output_path.replace(".parquet", ".xlsx")
-    final_df.to_excel(final_excel_path, index=False)
-    print(f"✅ Saved final DataFrame as Excel to: {final_excel_path}")
-
-    _print_final_stats_and_preview(final_df, var_categories, rdf_files, file_path)
-
-    return final_table, final_variable_metadata
+    return final_table, metadata
 
 
-def _print_final_stats_and_preview(df: pd.DataFrame,
-                                   var_categories: dict,
-                                   rdf_files: list,
-                                   file_path: str) -> None:
-    """
-    Print final dataset statistics and a preview row.
+def _collect_rdf_files(path):
+    rdf_exts = ('.ttl', '.jsonld', '.json-ld')
+    if os.path.isfile(path) and path.lower().endswith(rdf_exts):
+        return [path]
+    rdf_files = []
+    for root, _, files in os.walk(path):
+        rdf_files += [os.path.join(root, f) for f in files if f.lower().endswith(rdf_exts)]
+    return rdf_files
 
-    Args:
-        df (pd.DataFrame): Final DataFrame.
-        var_categories (dict): Mapping from variable names to categories.
-        rdf_files (list): List of RDF files parsed.
-        file_path (str): Original input path.
-    """
-    num_rows = len(df)
-    num_cols = len(df.columns)
-    distinct_categories = set()
 
-    for col in df.columns:
-        cat = var_categories.get(col, "")
-        if cat:
-            distinct_categories.add(cat)
+def _reorder_columns(df, categories):
+    cols = list(df.columns)
+    if "ExperimentId" in cols:
+        cols.remove("ExperimentId")
+    cols.sort(key=lambda c: (categories.get(c, ""), c))
+    return df[["ExperimentId"] + cols] if "ExperimentId" in df.columns else df[cols]
 
-    print("\n=== Final Conversion Stats ===")
-    if len(rdf_files) == 1:
-        print(f"Source: Single RDF file => {rdf_files[0]}")
+
+def _save_all_outputs(df, arrow_table, meta_json_path, arrow_path):
+    os.makedirs(os.path.dirname(meta_json_path), exist_ok=True)
+    os.makedirs(os.path.dirname(arrow_path), exist_ok=True)
+
+    with open(meta_json_path, "w", encoding="utf-8") as f:
+        json.dump(df.dtypes.apply(str).to_dict(), f, indent=2)
+
+    if meta_json_path.lower().endswith(".json"):
+        meta_csv_path = meta_json_path.replace(".json", ".csv")
+        df.dtypes.to_frame("dtype").reset_index().rename(columns={"index": "Variable"}).to_csv(meta_csv_path, index=False)
+        print(f"✅ Metadata CSV: {meta_csv_path}")
+
+    arrow_dir = os.path.dirname(arrow_path)
+    stem = os.path.splitext(os.path.basename(arrow_path))[0]
+
+    pq.write_table(arrow_table, arrow_path)
+    df.to_json(os.path.join(arrow_dir, f"{stem}.json"), orient="records", indent=2)
+    df.to_csv(os.path.join(arrow_dir, f"{stem}.csv"), index=False)
+    df.to_excel(os.path.join(arrow_dir, f"{stem}.xlsx"), index=False)
+    print(f"✅ Saved Arrow/CSV/Excel/JSON under: {arrow_dir}")
+
+
+def _print_final_stats_and_preview(df, categories, rdf_files, src):
+    print("\n📊 Final Stats")
+    print(f"Files Processed: {len(rdf_files)} from {src}")
+    print(f"Rows: {len(df)}, Columns: {len(df.columns)}")
+
+    unique_cats = sorted(set(categories.values()) - {""})
+    if unique_cats:
+        print(f"Variable Categories: {len(unique_cats)} ({', '.join(unique_cats)})")
     else:
-        print(f"Source: {len(rdf_files)} RDF files from => {file_path}")
+        print("No variable categories detected.")
 
-    print(f"Total Rows (Experiments): {num_rows}")
-    print(f"Total Columns (Variables): {num_cols}")
-
-    if distinct_categories:
-        cats_sorted = sorted(distinct_categories)
-        print(f"Distinct Categories Found: {len(cats_sorted)} ({', '.join(cats_sorted)})")
-    else:
-        print("Distinct Categories Found: 0")
-
-    if num_rows > 0:
-        print("\n=== First Row Preview ===")
+    if not df.empty:
+        print("🔎 First Row Preview:")
         print(df.iloc[0].to_dict())
     else:
-        print("\nNo data rows found.")
-
-
-def _collect_rdf_files(file_path):
-    """
-    Collect RDF files from a single file or a directory.
-
-    Args:
-        file_path (str): Input file or directory path.
-
-    Returns:
-        list: List of RDF file paths (.ttl, .jsonld, .json-ld).
-    """
-    rdf_files = []
-    if os.path.isfile(file_path):
-        if file_path.lower().endswith(('.ttl', '.jsonld', '.json-ld')):
-            return [file_path]
-    elif os.path.isdir(file_path):
-        for root, _, files in os.walk(file_path):
-            for fname in files:
-                if fname.lower().endswith(('.ttl', '.jsonld', '.json-ld')):
-                    rdf_files.append(os.path.join(root, fname))
-    return rdf_files
+        print("⚠️ No rows found.")

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,15 @@ from setuptools import setup, find_packages
 
 setup(
     name='FAIRLinked',
-    version='0.2.0.4',
-    description='Transform research data into FAIR-compliant RDF using the RDF Data Cube Vocabulary. Align your datasets with MDS-Onto and convert them into Linked Data, enhancing interoperability and reusability for seamless data integration. See the README or vignette for more information. This tool is used by the SDLE Research Center at Case Western Reserve University.',
+    version='0.3.0.0',  # ⬅️ Updated version to match recent work
+    description='Transform research data into FAIR-compliant RDF using the RDF Data Cube Vocabulary.',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     author='Balashanmuga Priyan Rajamohan, Kai Zheng, Benjamin Pierce, Erika I. Barcelos, Roger H. French',
     author_email='rxf131@case.edu',
     license='BSD-2-Clause',
-    packages=find_packages(),
+    packages=find_packages(where='packages'),  # ⬅️ Ensure your code is under 'packages/'
+    package_dir={'': 'packages'},              # ⬅️ Map logical root to physical 'packages/'
     install_requires=[
         'rdflib>=7.0.0',
         'typing-extensions>=4.0.0',
@@ -28,5 +29,15 @@ setup(
             'FAIRLinked=FAIRLinked.__main__:main'
         ]
     },
+    include_package_data=True,
+    zip_safe=False,
     python_requires='>=3.9.18',
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.9',
+        'Intended Audience :: Science/Research',
+        'Topic :: Scientific/Engineering :: Information Analysis'
+    ],
 )


### PR DESCRIPTION
### Summary

This PR introduces the following changes for version `v0.3.0.0` of FAIRLinked:

- ✅ Updated `setup.py` to be PyPI-compliant and reflect correct version
- ✅ Corrected `mds` namespace in `csv_to_jsonld_mapper.py` for alignment with FAIR ontologies
- ✅ Added new function to convert JSON-LD directory → single CSV with:
  - `skos:altLabel` as column names
  - `qudt:value` as row values
  - Additional header rows for `@type` and `qudt:hasUnit`
- ✅ Cleaned up and modularized existing FAIRLinkedPy package functions

### Context

These changes are part of ongoing work to:
- Make FAIRLinked publishable and installable via PyPI
- Add reverse conversion utilities for data usability
- Improve script maintainability for SDLE and collaborators